### PR TITLE
Fix mistaken ramstyle inference

### DIFF
--- a/rtl/gauntlet/LINEBUF.vhd
+++ b/rtl/gauntlet/LINEBUF.vhd
@@ -36,7 +36,7 @@ architecture RTL of LINEBUF is
 	type RAM_ARRAY is array (0 to 511) of std_logic_vector(7 downto 0);
 	signal RAM : RAM_ARRAY := ((others=>(others=>'1')));
 	attribute ramstyle : string;
-	attribute ramstyle of RAM : signal is "logic";
+	attribute ramstyle of RAM : signal is "M10K";
 
 	signal
 		sl_CLRn,

--- a/rtl/gauntlet/PFHS.vhd
+++ b/rtl/gauntlet/PFHS.vhd
@@ -92,7 +92,7 @@ begin
 	p_4M_5M : process
 	variable RAM : RAM_ARRAY;
 	attribute ramstyle : string;
-	attribute ramstyle of RAM : variable is "M10K";
+	attribute ramstyle of RAM : variable is "logic";
 	begin
 		wait until falling_edge(I_CK);
 		slv_4D <= RAM(to_integer(unsigned(RAM_4M_5M_addr))); -- 4D latch


### PR DESCRIPTION
I accidentally swapped these two somehow in my previous pull request.